### PR TITLE
[EDC-6041] add: Enable Dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/.github/**/*"
+    schedule:
+      interval: "quarterly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions-all:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "SonySemiconductorSolutions/*"


### PR DESCRIPTION
Github actions向けのDependabotを導入します。

導入yml: 通常版
更新対象ブランチ: デフォルトブランチ
更新対象: workflowとcompoiste actionで利用されている外部action
PR粒度: 全てのactionバージョン更新を1つまとめる
経緯・詳細: [Ticket](https://aitrios.atlassian.net/browse/EDC-6041)参照